### PR TITLE
HATEOAS added, Update dependencies and enhance API versioning support

### DIFF
--- a/api/Directory.Packages.props
+++ b/api/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageVersion Include="EFCore.NamingConventions" Version="9.0.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="9.0.3" />

--- a/api/TeamA.DevFollow.API/Controllers/HabitTagsController.cs
+++ b/api/TeamA.DevFollow.API/Controllers/HabitTagsController.cs
@@ -1,8 +1,4 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using TeamA.DevFollow.API.Database;
-using TeamA.DevFollow.API.DTOs.HabitTags;
-using TeamA.DevFollow.API.Entities;
 
 namespace TeamA.DevFollow.API.Controllers;
 
@@ -10,6 +6,8 @@ namespace TeamA.DevFollow.API.Controllers;
 [Route("habits/{habitId}/tags")]
 public sealed class HabitTagsController(ApplicationDbContext dbContext) : ControllerBase
 {
+    public static readonly string Name = nameof(HabitTagsController).Replace("Controller", string.Empty);
+
     [HttpPut]
     public async Task<ActionResult> UpsertHabitTags(string habitId, UpsertHabitTagsDto upsertHabitTagsDto)
     {

--- a/api/TeamA.DevFollow.API/Controllers/HabitsController.cs
+++ b/api/TeamA.DevFollow.API/Controllers/HabitsController.cs
@@ -1,4 +1,7 @@
 ﻿using System.Dynamic;
+using System.Linq.Dynamic.Core;
+using System.Net.Mime;
+using Asp.Versioning;
 using FluentValidation;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
@@ -14,9 +17,11 @@ namespace TeamA.DevFollow.API.Controllers;
 
 [ApiController]
 [Route("habits")]
-public sealed class HabitsController(ApplicationDbContext dbContext) : ControllerBase
+[ApiVersion(1.0)]
+public sealed class HabitsController(ApplicationDbContext dbContext, LinkService linkService) : ControllerBase
 {
     [HttpGet]
+    [Produces(MediaTypeNames.Application.Json, CustomMediaTypeNames.Application.HateoasJson)]
     public async Task<IActionResult> GetHabits(
         [FromQuery] HabitsQueryParameters query,
         SortMappingProvider sortMappingProvider,
@@ -57,21 +62,35 @@ public sealed class HabitsController(ApplicationDbContext dbContext) : Controlle
             .Take(query.PageSize)
             .ToListAsync();
 
+        bool includeLinks = query.Accept == CustomMediaTypeNames.Application.HateoasJson;
         var paginationResult = new PaginationResult<ExpandoObject>
         {
-            Items = dataShapingService.ShapeCollectionData(habits, query.Fields),
+            Items = dataShapingService.ShapeCollectionData(
+                habits,
+                query.Fields,
+                includeLinks ? h => CreateLinksForHabit(h.Id, query.Fields) : null),
             Page = query.Page,
             PageSize = query.PageSize,
             TotalCount = totalCount
         };
+        if (includeLinks)
+        {
+            paginationResult.Links = CreateLinksForHabits(
+                query,
+                paginationResult.HasNextPage,
+                paginationResult.HasPreviousPage);
+        }
 
         return Ok(paginationResult);
     }
 
     [HttpGet("{id}")]
+    [MapToApiVersion(1.0)]
     public async Task<IActionResult> GetHabit(
         string id,
         string? fields,
+        [FromHeader(Name = "Accept")]
+        string? accept,
         DataShapingService dataShapingService)
     {
         if (!dataShapingService.Validate<HabitWithTagsDto>(fields))
@@ -94,6 +113,52 @@ public sealed class HabitsController(ApplicationDbContext dbContext) : Controlle
 
         ExpandoObject shapedHabitDto = dataShapingService.ShapeData(habit, fields);
 
+        if (accept == CustomMediaTypeNames.Application.HateoasJson)
+        {
+            List<LinkDto> links = CreateLinksForHabit(id, fields);
+
+            shapedHabitDto.TryAdd("links", links);
+        }
+
+        return Ok(shapedHabitDto);
+    }
+
+    [HttpGet("{id}")]
+    [ApiVersion(2.0)]
+    public async Task<IActionResult> GetHabitV2(
+        string id,
+        string? fields,
+        [FromHeader(Name = "Accept")]
+        string? accept,
+        DataShapingService dataShapingService)
+    {
+        if (!dataShapingService.Validate<HabitWithTagsDtoV2>(fields))
+        {
+            return Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                detail: $"The provided data shaping fields aren't valid: '{fields}'");
+        }
+
+        HabitWithTagsDtoV2? habit = await dbContext
+            .Habits
+            .Where(h => h.Id == id)
+            .Select(HabitQueries.ProjectToDtoWithTagsV2())
+            .FirstOrDefaultAsync();
+
+        if (habit is null)
+        {
+            return NotFound();
+        }
+
+        ExpandoObject shapedHabitDto = dataShapingService.ShapeData(habit, fields);
+
+        if (accept == CustomMediaTypeNames.Application.HateoasJson)
+        {
+            List<LinkDto> links = CreateLinksForHabit(id, fields);
+
+            shapedHabitDto.TryAdd("links", links);
+        }
+
         return Ok(shapedHabitDto);
     }
 
@@ -111,6 +176,7 @@ public sealed class HabitsController(ApplicationDbContext dbContext) : Controlle
         await dbContext.SaveChangesAsync();
 
         HabitDto habitDto = habit.ToDto();
+        habitDto.Links = CreateLinksForHabit(habit.Id, null);
 
         return CreatedAtAction(nameof(GetHabit), new { id = habitDto.Id }, habitDto);
     }
@@ -175,5 +241,74 @@ public sealed class HabitsController(ApplicationDbContext dbContext) : Controlle
         await dbContext.SaveChangesAsync();
 
         return NoContent();
+    }
+
+    private List<LinkDto> CreateLinksForHabits(
+        HabitsQueryParameters parameters,
+        bool hasNextPage,
+        bool hasPreviousPage)
+    {
+        List<LinkDto> links =
+        [
+            linkService.Create(nameof(GetHabits), "self", HttpMethods.Get, new
+            {
+                page = parameters.Page,
+                pageSize = parameters.PageSize,
+                fields = parameters.Fields,
+                q = parameters.Search,
+                sort = parameters.Sort,
+                type = parameters.Type,
+                status = parameters.Status
+            }),
+            linkService.Create(nameof(CreateHabit), "create", HttpMethods.Post)
+        ];
+
+        if (hasNextPage)
+        {
+            links.Add(linkService.Create(nameof(GetHabits), "next-page", HttpMethods.Get, new
+            {
+                page = parameters.Page + 1,
+                pageSize = parameters.PageSize,
+                fields = parameters.Fields,
+                q = parameters.Search,
+                sort = parameters.Sort,
+                type = parameters.Type,
+                status = parameters.Status
+            }));
+        }
+
+        if (hasPreviousPage)
+        {
+            links.Add(linkService.Create(nameof(GetHabits), "previous-page", HttpMethods.Get, new
+            {
+                page = parameters.Page - 1,
+                pageSize = parameters.PageSize,
+                fields = parameters.Fields,
+                q = parameters.Search,
+                sort = parameters.Sort,
+                type = parameters.Type,
+                status = parameters.Status
+            }));
+        }
+
+        return links;
+    }
+
+    private List<LinkDto> CreateLinksForHabit(string id, string? fields)
+    {
+        List<LinkDto> links =
+        [
+            linkService.Create(nameof(GetHabit), "self", HttpMethods.Get, new { id, fields }),
+            linkService.Create(nameof(UpdateHabit), "update", HttpMethods.Put, new { id }),
+            linkService.Create(nameof(PatchHabit), "partial-update", HttpMethods.Patch, new { id }),
+            linkService.Create(nameof(DeleteHabit), "delete", HttpMethods.Delete, new { id }),
+            linkService.Create(
+                nameof(HabitTagsController.UpsertHabitTags),
+                "upsert-tags",
+                HttpMethods.Put,
+                new { habitId = id },
+                HabitTagsController.Name)
+        ];
+        return links;
     }
 }

--- a/api/TeamA.DevFollow.API/Controllers/TagsController.cs
+++ b/api/TeamA.DevFollow.API/Controllers/TagsController.cs
@@ -2,10 +2,6 @@
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
-using Microsoft.EntityFrameworkCore;
-using TeamA.DevFollow.API.Database;
-using TeamA.DevFollow.API.DTOs.Tags;
-using TeamA.DevFollow.API.Entities;
 
 namespace TeamA.DevFollow.API.Controllers;
 

--- a/api/TeamA.DevFollow.API/DTOs/Common/ILinksResponse.cs
+++ b/api/TeamA.DevFollow.API/DTOs/Common/ILinksResponse.cs
@@ -1,0 +1,6 @@
+﻿namespace TeamA.DevFollow.API.DTOs.Common;
+
+public interface ILinksResponse
+{
+    List<LinkDto> Links { get; set; }
+}

--- a/api/TeamA.DevFollow.API/DTOs/Common/LinkDto.cs
+++ b/api/TeamA.DevFollow.API/DTOs/Common/LinkDto.cs
@@ -1,0 +1,8 @@
+﻿namespace TeamA.DevFollow.API.DTOs.Common;
+
+public sealed class LinkDto
+{
+    public required string Href { get; init; }
+    public required string Rel { get; init; }
+    public required string Method { get; init; }
+}

--- a/api/TeamA.DevFollow.API/DTOs/Common/PaginationResult.cs
+++ b/api/TeamA.DevFollow.API/DTOs/Common/PaginationResult.cs
@@ -2,12 +2,13 @@
 
 namespace TeamA.DevFollow.API.DTOs.Common;
 
-public sealed record PaginationResult<T> : ICollectionResponse<T>
+public sealed record PaginationResult<T> : ICollectionResponse<T>, ILinksResponse
 {
     public List<T> Items { get; init; }
     public int Page { get; init; }
     public int PageSize { get; init; }
     public int TotalCount { get; init; }
+    public List<LinkDto> Links { get; set; }
 
     public int TotalPages => (int)Math.Ceiling(TotalCount / (double)PageSize);
     public bool HasPreviousPage => Page > 1;

--- a/api/TeamA.DevFollow.API/DTOs/Habits/CreateHabitDtoValidator.cs
+++ b/api/TeamA.DevFollow.API/DTOs/Habits/CreateHabitDtoValidator.cs
@@ -1,5 +1,4 @@
 ﻿using FluentValidation;
-using TeamA.DevFollow.API.Entities;
 
 namespace TeamA.DevFollow.API.DTOs.Habits;
 

--- a/api/TeamA.DevFollow.API/DTOs/Habits/HabitDto.cs
+++ b/api/TeamA.DevFollow.API/DTOs/Habits/HabitDto.cs
@@ -1,8 +1,9 @@
-﻿using TeamA.DevFollow.API.Entities;
+﻿using TeamA.DevFollow.API.DTOs.Common;
+using TeamA.DevFollow.API.Entities;
 
 namespace TeamA.DevFollow.API.DTOs.Habits;
 
-public sealed record HabitDto
+public sealed record HabitDto : ILinksResponse
 {
     public required string Id { get; init; }
     public required string Name { get; init; }
@@ -17,6 +18,7 @@ public sealed record HabitDto
     public required DateTime CreatedAtUtc { get; init; }
     public DateTime? UpdatedAtUtc { get; init; }
     public DateTime? LastCompletedAtUtc { get; init; }
+    public List<LinkDto> Links { get; set; }
 }
 
 public sealed record FrequencyDto

--- a/api/TeamA.DevFollow.API/DTOs/Habits/HabitQueries.cs
+++ b/api/TeamA.DevFollow.API/DTOs/Habits/HabitQueries.cs
@@ -69,4 +69,37 @@ internal static class HabitQueries
             Tags = h.Tags.Select(t => t.Name).ToArray()
         };
     }
+
+    public static Expression<Func<Habit, HabitWithTagsDtoV2>> ProjectToDtoWithTagsV2()
+    {
+        return h => new HabitWithTagsDtoV2
+        {
+            Id = h.Id,
+            Name = h.Name,
+            Description = h.Description,
+            Type = h.Type,
+            Frequency = new FrequencyDto
+            {
+                Type = h.Frequency.Type,
+                TimesPerPeriod = h.Frequency.TimesPerPeriod
+            },
+            Target = new TargetDto
+            {
+                Value = h.Target.Value,
+                Unit = h.Target.Unit
+            },
+            Status = h.Status,
+            IsArchived = h.IsArchived,
+            EndDate = h.EndDate,
+            Milestone = h.Milestone == null ? null : new MilestoneDto
+            {
+                Target = h.Milestone.Target,
+                Current = h.Milestone.Current
+            },
+            CreatedAt = h.CreatedAtUtc,
+            UpdatedAt = h.UpdatedAtUtc,
+            LastCompletedAt = h.LastCompletedAtUtc,
+            Tags = h.Tags.Select(t => t.Name).ToArray()
+        };
+    }
 }

--- a/api/TeamA.DevFollow.API/DTOs/Habits/HabitWithTagsDtoV2.cs
+++ b/api/TeamA.DevFollow.API/DTOs/Habits/HabitWithTagsDtoV2.cs
@@ -1,0 +1,19 @@
+﻿namespace TeamA.DevFollow.API.DTOs.Habits;
+
+public sealed record HabitWithTagsDtoV2
+{
+    public required string Id { get; init; }
+    public required string Name { get; init; }
+    public string? Description { get; init; }
+    public required HabitType Type { get; init; }
+    public required FrequencyDto Frequency { get; init; }
+    public required TargetDto Target { get; init; }
+    public required HabitStatus Status { get; init; }
+    public required bool IsArchived { get; init; }
+    public DateOnly? EndDate { get; init; }
+    public MilestoneDto? Milestone { get; init; }
+    public required DateTime CreatedAt { get; init; }
+    public DateTime? UpdatedAt { get; init; }
+    public DateTime? LastCompletedAt { get; init; }
+    public required string[] Tags { get; init; }
+}

--- a/api/TeamA.DevFollow.API/DTOs/Habits/HabitsQueryParameters.cs
+++ b/api/TeamA.DevFollow.API/DTOs/Habits/HabitsQueryParameters.cs
@@ -13,4 +13,6 @@ public sealed record HabitsQueryParameters
     public string? Fields { get; init; }
     public int Page { get; init; } = 1;
     public int PageSize { get; init; } = 10;
+    [FromHeader(Name = "Accept")]
+    public string? Accept { get; init; }
 }

--- a/api/TeamA.DevFollow.API/DTOs/Tags/TagMappings.cs
+++ b/api/TeamA.DevFollow.API/DTOs/Tags/TagMappings.cs
@@ -1,6 +1,4 @@
-﻿using TeamA.DevFollow.API.Entities;
-
-namespace TeamA.DevFollow.API.DTOs.Tags;
+﻿namespace TeamA.DevFollow.API.DTOs.Tags;
 
 internal static class TagMappings
 {

--- a/api/TeamA.DevFollow.API/DTOs/Tags/TagQueries.cs
+++ b/api/TeamA.DevFollow.API/DTOs/Tags/TagQueries.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq.Expressions;
-using TeamA.DevFollow.API.Entities;
 
 namespace TeamA.DevFollow.API.DTOs.Tags;
 

--- a/api/TeamA.DevFollow.API/DependencyInjection.cs
+++ b/api/TeamA.DevFollow.API/DependencyInjection.cs
@@ -1,4 +1,7 @@
-﻿using FluentValidation;
+﻿using Asp.Versioning;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Newtonsoft.Json.Serialization;
@@ -18,7 +21,7 @@ namespace TeamA.DevFollow.API;
 
 public static class DependencyInjection
 {
-    public static WebApplicationBuilder AddControllers(this WebApplicationBuilder builder)
+    public static WebApplicationBuilder AddApiServices(this WebApplicationBuilder builder)
     {
         builder.Services.AddControllers(options =>
             {
@@ -27,6 +30,35 @@ public static class DependencyInjection
             .AddNewtonsoftJson(options => options.SerializerSettings.ContractResolver =
                 new CamelCasePropertyNamesContractResolver())
             .AddXmlSerializerFormatters();
+
+        builder.Services.Configure<MvcOptions>(options =>
+        {
+            NewtonsoftJsonOutputFormatter formatter = options.OutputFormatters
+                .OfType<NewtonsoftJsonOutputFormatter>()
+                .First();
+
+            formatter.SupportedMediaTypes.Add(CustomMediaTypeNames.Application.JsonV1);
+            formatter.SupportedMediaTypes.Add(CustomMediaTypeNames.Application.JsonV2);
+            formatter.SupportedMediaTypes.Add(CustomMediaTypeNames.Application.HateoasJson);
+            formatter.SupportedMediaTypes.Add(CustomMediaTypeNames.Application.HateoasJsonV1);
+            formatter.SupportedMediaTypes.Add(CustomMediaTypeNames.Application.HateoasJsonV2);
+        });
+
+        builder.Services
+            .AddApiVersioning(options =>
+            {
+                options.DefaultApiVersion = new ApiVersion(1.0);
+                options.AssumeDefaultVersionWhenUnspecified = true;
+                options.ReportApiVersions = true;
+                options.ApiVersionSelector = new DefaultApiVersionSelector(options);
+
+                options.ApiVersionReader = ApiVersionReader.Combine(
+                    new MediaTypeApiVersionReader(),
+                    new MediaTypeApiVersionReaderBuilder()
+                        .Template("application/vnd.dev-habit.hateoas.{version}+json")
+                        .Build());
+            })
+            .AddMvc();
 
         builder.Services.AddOpenApi();
 
@@ -93,6 +125,9 @@ public static class DependencyInjection
             HabitMappings.SortMapping);
 
         builder.Services.AddTransient<DataShapingService>();
+
+        builder.Services.AddHttpContextAccessor();
+        builder.Services.AddTransient<LinkService>();
 
         return builder;
     }

--- a/api/TeamA.DevFollow.API/Program.cs
+++ b/api/TeamA.DevFollow.API/Program.cs
@@ -1,10 +1,11 @@
+
 using TeamA.DevFollow.API;
 using TeamA.DevFollow.API.Extensions;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder
-    .AddControllers()
+    .AddApiServices()
     .AddErrorHandling()
     .AddDatabase()
     .AddObservability()

--- a/api/TeamA.DevFollow.API/Services/CustomMediaTypeNames.cs
+++ b/api/TeamA.DevFollow.API/Services/CustomMediaTypeNames.cs
@@ -1,0 +1,13 @@
+﻿namespace TeamA.DevFollow.API.Services;
+
+public static class CustomMediaTypeNames
+{
+    public static class Application
+    {
+        public const string JsonV1 = "application/json;v=1";
+        public const string JsonV2 = "application/json;v=2";
+        public const string HateoasJson = "application/vnd.dev-habit.hateoas+json";
+        public const string HateoasJsonV1 = "application/vnd.dev-habit.hateoas.1+json";
+        public const string HateoasJsonV2 = "application/vnd.dev-habit.hateoas.2+json";
+    }
+}

--- a/api/TeamA.DevFollow.API/Services/DataShapingService.cs
+++ b/api/TeamA.DevFollow.API/Services/DataShapingService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using System.Dynamic;
 using System.Reflection;
+using TeamA.DevFollow.API.DTOs.Common;
 
 namespace TeamA.DevFollow.API.Services;
 
@@ -36,7 +37,10 @@ public sealed class DataShapingService
         return (ExpandoObject)shapedObject;
     }
 
-    public List<ExpandoObject> ShapeCollectionData<T>(IEnumerable<T> entities, string? fields)
+    public List<ExpandoObject> ShapeCollectionData<T>(
+        IEnumerable<T> entities,
+        string? fields,
+        Func<T, List<LinkDto>>? linksFactory = null)
     {
         HashSet<string> fieldsSet = fields?
             .Split(',', StringSplitOptions.RemoveEmptyEntries)
@@ -62,6 +66,11 @@ public sealed class DataShapingService
             foreach (PropertyInfo propertyInfo in propertyInfos)
             {
                 shapedObject[propertyInfo.Name] = propertyInfo.GetValue(entity);
+            }
+
+            if (linksFactory is not null)
+            {
+                shapedObject["links"] = linksFactory(entity);
             }
 
             shapedObjects.Add((ExpandoObject)shapedObject);

--- a/api/TeamA.DevFollow.API/Services/LinkService.cs
+++ b/api/TeamA.DevFollow.API/Services/LinkService.cs
@@ -1,0 +1,27 @@
+﻿using TeamA.DevFollow.API.DTOs.Common;
+
+namespace TeamA.DevFollow.API.Services;
+
+public sealed class LinkService(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+{
+    public LinkDto Create(
+        string endpointName,
+        string rel,
+        string method,
+        object? values = null,
+        string? controller = null)
+    {
+        string? href = linkGenerator.GetUriByAction(
+            httpContextAccessor.HttpContext!,
+            endpointName,
+            controller,
+            values);
+
+        return new LinkDto
+        {
+            Href = href ?? throw new Exception("Invalid endpoint name provided"),
+            Rel = rel,
+            Method = method
+        };
+    }
+}

--- a/api/TeamA.DevFollow.API/TeamA.DevFollow.API.csproj
+++ b/api/TeamA.DevFollow.API/TeamA.DevFollow.API.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc" />
     <PackageReference Include="EFCore.NamingConventions" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" />


### PR DESCRIPTION
HATEOAS added, Update dependencies and enhance API versioning support

- Updated `Directory.Packages.props` with new package versions.
- Refactored `HabitTagsController` to include an `UpsertHabitTags` method.
- Enhanced `HabitsController` with API versioning and pagination links.
- Introduced `ILinksResponse` interface and `LinkDto` class for HATEOAS.
- Updated `PaginationResult` to support links in responses.
- Added `HabitWithTagsDtoV2` for versioned habit representation.
- Cleaned up using directives in various files and corrected namespaces.
- Modified `DependencyInjection` and `Program` for new service registrations.
- Created `CustomMediaTypeNames` for versioning support.
- Updated `DataShapingService` to generate links in shaped data responses.
- Added `LinkService` for HATEOAS link creation.

#### PR Classification
Enhancement of API functionality and structure.

#### PR Summary
This pull request introduces several enhancements to the API, including support for HATEOAS links and improved data shaping. Key changes include:
- `HabitsController.cs`: Added pagination and HATEOAS link support, modified constructor to include `LinkService`.
- `HabitTagsController.cs`: Introduced `UpsertHabitTags` method and added a static `Name` property for link creation.
- `ILinksResponse.cs` and `LinkDto.cs`: Created an interface and class to standardize link inclusion in responses.
- `PaginationResult.cs`: Updated to implement `ILinksResponse`, allowing links in paginated responses.
- `DependencyInjection.cs`: Renamed service registration method to `AddApiServices` and configured API versioning.
